### PR TITLE
Assign a $PORT number for each process

### DIFF
--- a/shoreman.sh
+++ b/shoreman.sh
@@ -46,9 +46,14 @@ store_pid() {
 # This starts a command asynchronously and stores its pid in a list for use
 # later on in the script.
 start_command() {
-  sh -c "$1" &
+  sh -c "PORT=$(get_port) $1" &
   pid="$!"
   store_pid "$pid"
+}
+
+get_port() {
+  PORT=${PORT:-5000}
+  echo $((PORT + 100))
 }
 
 # ## Reading the Procfile

--- a/test/fixtures/port_procfile
+++ b/test/fixtures/port_procfile
@@ -1,0 +1,1 @@
+web: echo PORT = $PORT

--- a/test/shoreman_test.sh
+++ b/test/shoreman_test.sh
@@ -14,3 +14,8 @@ it_passes_environment_variables_to_processes() {
   output=$(FOO=bar bash ./shoreman.sh 'test/fixtures/environment_procfile' | head -n1)
   test "$output" = "FOO = bar"
 }
+
+it_automatically_assigns_a_port() {
+  output=$(bash ./shoreman.sh 'test/fixtures/port_procfile' | head -n1)
+  test "$output" = "PORT = 5000"
+}


### PR DESCRIPTION
Assign a `$PORT` environment variable to each process.
- Tests aren't _always_ passing…
- Default port can be set using the `$PORT` environment variable.
