### PR TITLE
fix for commented variables in .env

### DIFF
--- a/shoreman.sh
+++ b/shoreman.sh
@@ -64,7 +64,7 @@ start_command() {
 ENV_FILE=${2:-'.env'}
 if [ -f $ENV_FILE ]; then
   while read line || [ -n "$line" ]; do
-    if [[ "$line" == *=* ]]; then
+    if [[ "$line" != \#* && "$line" == *=* ]]; then
       eval "export $line"
     fi
   done < "$ENV_FILE"

--- a/test/fixtures/env_file_with_comments
+++ b/test/fixtures/env_file_with_comments
@@ -1,0 +1,3 @@
+# comment that could look like variable assignment:
+#FOO=bar
+# one more comment

--- a/test/shoreman_test.sh
+++ b/test/shoreman_test.sh
@@ -25,3 +25,9 @@ it_can_pass_env_file_as_second_argument() {
   output=$(bash ./shoreman.sh 'test/fixtures/env_file_arg_procfile' 'test/fixtures/env_file_arg' | head -n1)
   test "$output" = "MUZ = bar"
 }
+
+it_ignores_comments_in_env_file() {
+  cd "test/fixtures"
+  output=$(bash ../../shoreman.sh 'simple_procfile' 'env_file_with_comments' | head -n1)
+  test "$output" = "Hello"
+}


### PR DESCRIPTION
when .env contains commented environment variables
e.g.:

``` bash
RACK_ENV=development
#RACK_ENV=production
```

shoreman(actually "export" bash builtin) produces
noise like this:

```
declare -x ...
```

actually I don't know why exactly this happens and is my fix is portable and fully correct, so correct me if there is mistake. Also I'm ready to add test or change commit message.

Thanks!
