### PR TITLE
use bash to run new process

### DIFF
--- a/shoreman.sh
+++ b/shoreman.sh
@@ -50,7 +50,7 @@ store_pid() {
 # This starts a command asynchronously and stores its pid in a list for use
 # later on in the script.
 start_command() {
-  sh -c "$1" &
+  bash -c "$1" &
   pid="$!"
   store_pid "$pid"
 }


### PR DESCRIPTION
to avoid cases where `sh -c` aliased to shell
which forks itself before running command, so signal(2)s
from shoreman (e.g. SIGTERM) could not reach actual process

should fix #11
