### PR TITLE
Try to use all colors supported by the terminal.

### DIFF
--- a/shoreman.sh
+++ b/shoreman.sh
@@ -31,14 +31,12 @@ expr -- "$*" : ".*--help" >/dev/null && {
 # as the process name. This takes one argument, the name of the process, and
 # then reads data from stdin, formats it, and sends it to stdout.
 log() { (
-  # Bash colors start from 31 up to 38. Instead of a hash set and storing a
-  # bunch of variables, we will simply calculate what color the process will get
-  # base on its PID
-  color=$((31 + ($! % 7)))
+  # Calculate what color the process will get based on its PID
+  color=$(($! % $(tput colors)))
 
   while read -r data
   do
-    printf "\033[1;%sm%s %s\033[0m" "$color" "$(date +"%H:%M:%S")" "$1"
+    printf "%s%s %s\033[0m" "$(tput setaf $color)" "$(date +"%H:%M:%S")" "$1"
     printf "\t| %s\n" "$data"
   done
 ) }


### PR DESCRIPTION
This uses `tput colors` to get the number of available colors and `tput setaf $color` to set it.

I made the change because in my current setup, with 6 or 7 processes, they very often get the same gray color. Increasing the range of colors worked for me. I have 256 colors in my terminal. This approach should also degrade well if you have only 8 (kind of depends on your background color too).

I hacked this quickly, but let me know if you like it and we can think of a good way to do this.

