### PR TITLE
wip: allow processes to be started selectively

### DIFF
--- a/shoreman.sh
+++ b/shoreman.sh
@@ -12,10 +12,10 @@ set -e
 
 # Usage message that is displayed when `--help` is given as an argument.
 usage() {
-  echo "Usage: shoreman [procfile|Procfile] [envfile|.env]"
+  echo "Usage: shoreman [processes]"
   echo "Run Procfiles using shell."
   echo
-  echo "The shoreman script reads commands from [procfile] and starts up the"
+  echo "The shoreman script reads commands from Procfile and starts up the"
   echo "processes that it describes."
 }
 
@@ -67,7 +67,7 @@ PORT=${PORT:-5000}
 # The .env file needs to be a list of assignments like in a shell script.
 # Shell-style comments are permitted.
 
-ENV_FILE=${2:-'.env'}
+ENV_FILE=${ENV_FILE:-'.env'}
 if [ -f "$ENV_FILE" ]; then
   export $(grep "^[^#]*=.*" "$ENV_FILE" | xargs)
 fi
@@ -76,12 +76,28 @@ fi
 
 # The Procfile needs to be parsed to extract the process names and commands.
 # The file is given on stdin, see the `<` at the end of this while loop.
-PROCFILE=${1:-'Procfile'}
+commands=( "$@" )
+should_start_command() {
+  local command
+  if test "${#commands[@]}" -eq 0; then
+    return 0
+  fi
+  for command in "${commands[@]}"; do
+    if test "$command" = "$1"; then
+      return 0
+    fi
+  done
+  unset command
+  return 1
+}
+PROCFILE=${PROCFILE:-'Procfile'}
 while read line || [ -n "$line" ]; do
   name=${line%%:*}
   command=${line#*:[[:space:]]}
-  start_command "$command" "${name}"
-  echo "'${command}' started with pid $!" | log "${name}"
+  if should_start_command "$name"; then
+    start_command "$command" "$name"
+    echo "'${command}' started with pid $!" | log "${name}"
+  fi
 done < "$PROCFILE"
 
 # ## Cleanup

--- a/shoreman.sh
+++ b/shoreman.sh
@@ -76,25 +76,25 @@ fi
 
 # The Procfile needs to be parsed to extract the process names and commands.
 # The file is given on stdin, see the `<` at the end of this while loop.
-commands=( "$@" )
 should_start_command() {
-  local command
-  if test "${#commands[@]}" -eq 0; then
+  local command="$1"; shift
+  if test "$#" -eq 0; then
     return 0
   fi
-  for command in "${commands[@]}"; do
-    if test "$command" = "$1"; then
+  for e in "$@"; do
+    if test "$e" = "$command"; then
       return 0
     fi
   done
   unset command
   return 1
 }
+
 PROCFILE=${PROCFILE:-'Procfile'}
 while read line || [ -n "$line" ]; do
   name=${line%%:*}
   command=${line#*:[[:space:]]}
-  if should_start_command "$name"; then
+  if should_start_command "$name" "$@"; then
     start_command "$command" "$name"
     echo "'${command}' started with pid $!" | log "${name}"
   fi

--- a/test/shoreman_test.sh
+++ b/test/shoreman_test.sh
@@ -2,48 +2,48 @@ describe "Shoreman"
 
 it_displays_usage() {
   usage=$(./shoreman.sh --help | head -n1)
-  test "$usage" = "Usage: shoreman [procfile|Procfile] [envfile|.env]"
+  test "$usage" = "Usage: shoreman [processes]"
 }
 
 it_runs_simple_processes() {
-  output=$(./shoreman.sh 'test/fixtures/simple_procfile'; :)
+  output=$(PROCFILE=test/fixtures/simple_procfile ./shoreman.sh; :)
   echo "$output" | grep -q "Hello"
 }
 
 it_passes_environment_variables_to_processes() {
-  output=$(FOO=bar ./shoreman.sh 'test/fixtures/environment_procfile'; :)
+  output=$(FOO=bar PROCFILE=test/fixtures/environment_procfile ./shoreman.sh; :)
   echo "$output" | grep -q "FOO = bar"
 }
 
 it_supports_dot_env_file() {
   cd "test/fixtures"
-  output=$(../../shoreman.sh 'env_file_procfile'; :)
+  output=$(PROCFILE=env_file_procfile ../../shoreman.sh; :)
   echo "$output" | grep -q "BAZ = baz"
 }
 
-it_can_pass_env_file_as_second_argument() {
-  output=$(./shoreman.sh 'test/fixtures/env_file_arg_procfile' 'test/fixtures/env_file_arg'; :)
+it_can_pass_env_file_as_env_file() {
+  output=$(PROCFILE=test/fixtures/env_file_arg_procfile ENV_FILE=test/fixtures/env_file_arg ./shoreman.sh; :)
   echo "$output" | grep -q "MUZ = bar"
 }
 
 it_ignores_comments_in_env_file() {
   cd "test/fixtures"
-  output=$(../../shoreman.sh 'commented_environment_procfile' 'env_file_with_comments'; :)
+  output=$(PROCFILE=commented_environment_procfile ENV_FILE=env_file_with_comments ../../shoreman.sh; :)
   echo "$output" | grep -q "42 does not contain: bar"
 }
 
 it_assigns_a_default_port_number() {
-  output=$(./shoreman.sh 'test/fixtures/port_number_procfile'; :)
+  output=$(PROCFILE=test/fixtures/port_number_procfile ./shoreman.sh; :)
   echo "$output" | grep -q "5000"
 }
 
 it_allows_overriding_the_port_number() {
-  output=$(PORT=5555 ./shoreman.sh 'test/fixtures/port_number_procfile'; :)
+  output=$(PROCFILE=test/fixtures/port_number_procfile PORT=5555 ./shoreman.sh; :)
   echo "$output" | grep -q "5555"
 }
 
 it_allows_tabs_in_procfile() {
-  output=$(./shoreman.sh 'test/fixtures/tabs_procfile'; :)
+  output=$(PROCFILE=test/fixtures/tabs_procfile ./shoreman.sh; :)
   echo "$output"
   not_found='command not found'
   test "${output#*$not_found}" == "$output"


### PR DESCRIPTION
I wrote this patch after reading #20.  It replaces shoreman's arguments with process names:  `shoreman web` only starts web.  `shoreman web worker` starts web and worker.  `shoreman` starts everything.  To explicitly name a different `Procfile` or `.env`, `$PROCFILE` and `$ENV_FILE` can be specified.  I updated the tests to use that scheme and verify they continue to pass.

This change might not be appreciated, but I needed it for my use case and figured I'd send it upstream and see what you think.