### PR TITLE
Kill process tree

### DIFF
--- a/shoreman.sh
+++ b/shoreman.sh
@@ -93,8 +93,9 @@ run_procfile() {
 # should probably go at some point.
 onexit() {
   echo "SIGINT received"
+  trap - INT TERM # Clear all traps
   echo "sending SIGTERM to all processes"
-  kill $pids
+  kill -TERM 0 # Kill all subprocesses and self
   sleep 1
 }
 


### PR DESCRIPTION
This makes sure all children-of-children get killed, and not just the
toplevels.
