### PR TITLE
don't mix output; ability to force colors on/off

### DIFF
--- a/shoreman.sh
+++ b/shoreman.sh
@@ -28,14 +28,20 @@ usage() {
 # to stdout.
 log() {
   local index="$2"
-  # Bash colors start from 31 up to 37. We calculate what color the process
-  # gets based on its index.
-  local color="$((31 + (index % 7)))"
+  local format="%s %s\t| %s"
+
+  # We add colors when output is a terminal. `SHOREMAN_COLORS` can override it.
+  if [ -t 1 -o "$SHOREMAN_COLORS" == "always" ] \
+     && [ "$SHOREMAN_COLORS" != "never" ]; then
+    # Bash colors start from 31 up to 37. We calculate what color the process
+    # gets based on its index.
+    local color="$((31 + (index % 7)))"
+    format=$(printf "\033[0;%sm%%s %%s\t|\033[0m %%s" "$color")
+  fi
 
   while read -r data
   do
-    printf "\033[0;%sm%s %s\033[0m" "$color" "$(date +"%H:%M:%S")" "$1"
-    printf "\t| %s\n" "$data"
+    printf "$format\n" "$(date +"%H:%M:%S")" "$1" "$data"
   done
 }
 

--- a/shoreman.sh
+++ b/shoreman.sh
@@ -36,7 +36,7 @@ log() {
     # Bash colors start from 31 up to 37. We calculate what color the process
     # gets based on its index.
     local color="$((31 + (index % 7)))"
-    format=$(printf "\033[0;%sm%%s %%s\t|\033[0m %%s" "$color")
+    format="\033[0;${color}m%s %s\t|\033[0m %s"
   fi
 
   while read -r data

--- a/test/fixtures/fast_procfile
+++ b/test/fixtures/fast_procfile
@@ -1,0 +1,8 @@
+1: echo 1
+2: echo 2
+3: echo 3
+4: echo 4
+5: echo 5
+6: echo 6
+7: echo 7
+8: echo 8

--- a/test/shoreman_test.sh
+++ b/test/shoreman_test.sh
@@ -57,3 +57,14 @@ it_ignores_comments_in_proc_file() {
   line3=$(echo "$output" | grep "ghi" | wc -l)
   [ $line0 -eq 2 -a $line1 -eq 0 -a $line2 -eq 0 -a $line3 -eq 2 ]
 }
+
+it_doesnt_intermix_output() {
+  output=$(./shoreman.sh 'test/fixtures/fast_procfile'; :)
+  bad=$(echo "$output" | grep -v '^\d\d:\d\d:\d\d \d[[:space:]]|' | wc -l)
+  [ $bad -eq 0 ]
+}
+
+it_can_force_colors_on() {
+  output=$(SHOREMAN_COLORS=always ./shoreman.sh 'test/fixtures/simple_procfile'; :)
+  echo "$output" | grep -q $(printf "\033")
+}


### PR DESCRIPTION
Shoreman wrongly intermix output from different processes. With this `Procfile`:
```
1: echo 1
2: echo 2
3: echo 3
4: echo 4
5: echo 5
6: echo 6
7: echo 7
8: echo 8
```

I get the following output to `shoreman` command:
![image](https://cloud.githubusercontent.com/assets/510678/7795674/cd440778-02df-11e5-9cba-b0493051dbc0.png)

It happens because `log` function outputs [with two `printf` calls][1] at a time.

[1]: https://github.com/chrismytton/shoreman/blob/487992e612d7738/shoreman.sh#L37-L38

This pull requests fixes the bug, with tests.

While at it, I've added TTY autodetection. Colors are turned off when output is not a terminal (e.g., when redirecting). You can override it with `SHOREMAN_COLORS` environment variable:
```
env SHOREMAN_COLORS=never shoreman  # force colors off
env SHOREMAN_COLORS=always shoreman # force colors on (even if output is not TTY)
```