### PR TITLE
added -E option for grep to properly parse the intermix  test outpout

### DIFF
--- a/test/shoreman_test.sh
+++ b/test/shoreman_test.sh
@@ -60,7 +60,7 @@ it_ignores_comments_in_proc_file() {
 
 it_doesnt_intermix_output() {
   output=$(./shoreman.sh 'test/fixtures/fast_procfile'; :)
-  bad=$(echo "$output" | grep -v '^\d\d:\d\d:\d\d \d[[:space:]]|' | wc -l)
+  bad=$(echo "$output" | grep -E -v '^\d\d:\d\d:\d\d \d[[:space:]]|' | wc -l)
   [ $bad -eq 0 ]
 }
 


### PR DESCRIPTION
Identified that the test run by 'make' fails on RHEL6/7 and Ubuntu 16.04
```
frdeng@homeserver:~/build/github.com/shoreman$ make
bash test/roundup.sh test/shoreman_test.sh
Shoreman
  it_displays_usage:                               [PASS]
  it_runs_simple_processes:                        [PASS]
  it_passes_environment_variables_to_processes:    [PASS]
  it_supports_dot_env_file:                        [PASS]
  it_can_pass_env_file_as_second_argument:         [PASS]
  it_ignores_comments_in_env_file:                 [PASS]
  it_assigns_a_default_port_number:                [PASS]
  it_allows_overriding_the_port_number:            [PASS]
  it_allows_tabs_in_procfile:                      [PASS]
  it_ignores_comments_in_proc_file:                [PASS]
  it_doesnt_intermix_output:                       [FAIL]
     ./shoreman.sh test/fixtures/fast_procfile
     :
    + output='15:38:30 1	| '\''echo 1'\'' started with pid 8782
    15:38:30 1	| 1
    15:38:30 2	| '\''echo 2'\'' started with pid 8789
    15:38:30 2	| 2
    15:38:30 3	| '\''echo 3'\'' started with pid 8796
    15:38:30 3	| 3
    15:38:30 4	| 4
    15:38:30 4	| '\''echo 4'\'' started with pid 8803
    15:38:30 5	| '\''echo 5'\'' started with pid 8810
    15:38:30 5	| 5
    15:38:30 6	| '\''echo 6'\'' started with pid 8817
    15:38:30 6	| 6
    15:38:30 7	| 7
    15:38:30 7	| '\''echo 7'\'' started with pid 8824
    15:38:30 8	| '\''echo 8'\'' started with pid 8831
    15:38:30 8	| 8'
     echo '15:38:30 1	| '\''echo 1'\'' started with pid 8782
    15:38:30 1	| 1
    15:38:30 2	| '\''echo 2'\'' started with pid 8789
    15:38:30 2	| 2
    15:38:30 3	| '\''echo 3'\'' started with pid 8796
    15:38:30 3	| 3
    15:38:30 4	| 4
    15:38:30 4	| '\''echo 4'\'' started with pid 8803
    15:38:30 5	| '\''echo 5'\'' started with pid 8810
    15:38:30 5	| 5
    15:38:30 6	| '\''echo 6'\'' started with pid 8817
    15:38:30 6	| 6
    15:38:30 7	| 7
    15:38:30 7	| '\''echo 7'\'' started with pid 8824
    15:38:30 8	| '\''echo 8'\'' started with pid 8831
    15:38:30 8	| 8'
     grep -v '^\d\d:\d\d:\d\d \d[[:space:]]|'
     wc -l
    + bad=16
    + '[' 16 -eq 0 ']'
    exit code 1
  it_can_force_colors_on:                          [PASS]
=========================================================
Tests:   12 | Passed:  11 | Failed:   1
Makefile:3: recipe for target 'test' failed
make: *** [test] Error 2
```

The fix adds "-E" option(extended regexp) for grep in order to get it properly parse  '^\d\d:\d\d:\d\d \d[[:space:]]|'  with test output like this:
```
$ ./shoreman.sh 'test/fixtures/fast_procfile'
15:55:29 1	| 1
15:55:29 1	| 'echo 1' started with pid 10453
15:55:29 2	| 2
15:55:29 2	| 'echo 2' started with pid 10460
15:55:29 3	| 3
15:55:29 3	| 'echo 3' started with pid 10467
15:55:29 4	| 'echo 4' started with pid 10474
15:55:29 4	| 4
15:55:29 5	| 5
15:55:29 5	| 'echo 5' started with pid 10481
15:55:29 6	| 6
15:55:29 6	| 'echo 6' started with pid 10488
15:55:29 7	| 'echo 7' started with pid 10495
15:55:29 7	| 7
15:55:29 8	| 8
15:55:29 8	| 'echo 8' started with pid 10502

```