### PR TITLE
Align command name with spaces, not tabs

### DIFF
--- a/shoreman.sh
+++ b/shoreman.sh
@@ -82,28 +82,25 @@ load_env_file() {
 
 # The Procfile needs to be parsed to extract the process names and commands.
 run_procfile() {
-  local procfilename=${1:-'Procfile'}
-
-  local procfile=$(while read line || [[ -n "$line" ]]; do
-    if [[ -z "$line" ]] || [[ "$line" == \#* ]]; then continue; fi
-    echo "$line"
-  done < "$procfilename")
+  local procfile=${1:-'Procfile'}
 
   local maxlength=$(echo "$procfile" | while read line || [[ -n "$line" ]]; do
+    if [[ -z "$line" ]] || [[ "$line" == \#* ]]; then continue; fi
     local name="${line%%:*}"
     echo "$name"
-  done | wc -L)
+  done < "$procfile" | wc -L)
 
   # We give each process an index to track its color. We start with 1,
   # because it corresponds to green which is easier on the eye than red (0).
   local index=1
-  echo "$procfile" | while read line || [[ -n "$line" ]]; do
+  while read line || [[ -n "$line" ]]; do
+    if [[ -z "$line" ]] || [[ "$line" == \#* ]]; then continue; fi
     local name="${line%%:*}"
     local command="${line#*:[[:space:]]}"
     start_command "$command" "${name}" "$index" "$maxlength"
     echo "'${command}' started with pid $pid" | log "${name}" "$index" "$maxlength"
     index=$((index + 1))
-  done
+  done < "$procfile"
 }
 
 # ## Cleanup

--- a/shoreman.sh
+++ b/shoreman.sh
@@ -81,27 +81,29 @@ load_env_file() {
 # ## Reading the Procfile
 
 # The Procfile needs to be parsed to extract the process names and commands.
-# The file is given on stdin, see the `<` at the end of this while loop.
 run_procfile() {
-  local procfile=${1:-'Procfile'}
+  local procfilename=${1:-'Procfile'}
 
-  local maxlength=$(while read line || [[ -n "$line" ]]; do
+  local procfile=$(while read line || [[ -n "$line" ]]; do
     if [[ -z "$line" ]] || [[ "$line" == \#* ]]; then continue; fi
+    echo "$line"
+  done < "$procfilename")
+
+  local maxlength=$(echo "$procfile" | while read line || [[ -n "$line" ]]; do
     local name="${line%%:*}"
     echo "$name"
-  done < "$procfile" | wc -L)
+  done | wc -L)
 
   # We give each process an index to track its color. We start with 1,
   # because it corresponds to green which is easier on the eye than red (0).
   local index=1
-  while read line || [[ -n "$line" ]]; do
-    if [[ -z "$line" ]] || [[ "$line" == \#* ]]; then continue; fi
+  echo "$procfile" | while read line || [[ -n "$line" ]]; do
     local name="${line%%:*}"
     local command="${line#*:[[:space:]]}"
     start_command "$command" "${name}" "$index" "$maxlength"
     echo "'${command}' started with pid $pid" | log "${name}" "$index" "$maxlength"
     index=$((index + 1))
-  done < "$procfile"
+  done
 }
 
 # ## Cleanup


### PR DESCRIPTION
*work-in-progress, do not merge yet*

* [ ] check tests
* [ ] check it works on non-GNU `wc` (e.g. on Mac)
* [ ] describe rationale