### PR TITLE
Update Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ curl https://github.com/chrismytton/shoreman/raw/master/shoreman.sh -sLo ~/bin/s
 chmod 755 ~/bin/shoreman
 ```
 
-### Homebrew
+### macOS with Homebrew
 
-    brew install --HEAD chrismytton/formula/shoreman
+    brew install chrismytton/formula/shoreman
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ A shell implementation of [Foreman](https://github.com/ddollar/foreman). Starts 
 
 ## Install
 
+### macOS with Homebrew
+
+    brew install chrismytton/formula/shoreman
+
 ### Standalone
 
 Install as a standalone, change `~/bin/` to any other directory that's
@@ -14,10 +18,6 @@ in your `$PATH` if you wish.
 curl https://github.com/chrismytton/shoreman/raw/master/shoreman.sh -sLo ~/bin/shoreman && \
 chmod 755 ~/bin/shoreman
 ```
-
-### macOS with Homebrew
-
-    brew install chrismytton/formula/shoreman
 
 ## Usage
 


### PR DESCRIPTION
No need to use the `--HEAD` flag now that 1.0.0 has been released.