### PR TITLE
Fixed command output echoing to preserve spaces

### DIFF
--- a/shoreman.sh
+++ b/shoreman.sh
@@ -37,7 +37,7 @@ log() {
     format="\033[0;${color}m%s %s\t|\033[0m %s"
   fi
 
-  while read -r data
+  while IFS= read -r data
   do
     printf "$format\n" "$(date +"%H:%M:%S")" "$1" "$data"
   done

--- a/test/fixtures/whitespace_output_procfile
+++ b/test/fixtures/whitespace_output_procfile
@@ -1,0 +1,1 @@
+test: echo "   output whitespace	is	preserved	"

--- a/test/shoreman_test.sh
+++ b/test/shoreman_test.sh
@@ -68,3 +68,9 @@ it_can_force_colors_on() {
   output=$(SHOREMAN_COLORS=always ./shoreman.sh 'test/fixtures/simple_procfile'; :)
   echo "$output" | grep -q $(printf "\033")
 }
+
+it_preserves_output_whitespace() {
+  output=$(./shoreman.sh 'test/fixtures/whitespace_output_procfile'; :)
+  expected='   output whitespace	is	preserved	'
+  echo "$output" | grep -q -F "| ${expected}"
+}


### PR DESCRIPTION
Using `IFS= ` when reading lines with `read` ensures that Bash doesn't split words on any characters, but instead returns each line as read. This preserves command output properly, with indentation preserved.

Without this change, command output of pretty-printed JSON looks quite ugly for instance.

