### PR TITLE
Preserve Procfile command exit status

### DIFF
--- a/shoreman.sh
+++ b/shoreman.sh
@@ -121,8 +121,13 @@ main() {
 
   trap onexit INT TERM
 
-  # Wait for the children to finish executing before exiting.
-  wait $pids
+  exitcode=0
+  for pid in $pids; do
+      # Wait for the children to finish executing before exiting.
+      # If said children exitcode is not successful, collect it.
+      wait "${pid}" || exitcode=$?
+  done
+  exit $exitcode
 }
 
 main "$@"

--- a/test/fixtures/exitstatus_procfile
+++ b/test/fixtures/exitstatus_procfile
@@ -1,0 +1,1 @@
+failure: false

--- a/test/fixtures/mixed_exitstatus_procfile
+++ b/test/fixtures/mixed_exitstatus_procfile
@@ -1,0 +1,3 @@
+failure: false
+# this command needs to be slower that the first one, to attempt to override the previous failure exit status
+success: date

--- a/test/shoreman_test.sh
+++ b/test/shoreman_test.sh
@@ -79,3 +79,8 @@ it_preserves_exitstatus() {
   _exitstatus=$(./shoreman.sh 'test/fixtures/exitstatus_procfile' >/dev/null 2>/dev/null || exitstatus=$? ; echo "${exitstatus}")
   [ "${_exitstatus}" -eq 1 ]
 }
+
+it_preserves_mixed_exitstatus() {
+  _exitstatus=$(exitstatus=0 ; ./shoreman.sh 'test/fixtures/mixed_exitstatus_procfile' >/dev/null 2>/dev/null || exitstatus=$?; echo "${exitstatus}")
+  [ "${_exitstatus}" -eq 1 ]
+}

--- a/test/shoreman_test.sh
+++ b/test/shoreman_test.sh
@@ -74,3 +74,8 @@ it_preserves_output_whitespace() {
   expected='   output whitespace	is	preserved	'
   echo "$output" | grep -q -F "| ${expected}"
 }
+
+it_preserves_exitstatus() {
+  _exitstatus=$(./shoreman.sh 'test/fixtures/exitstatus_procfile' >/dev/null 2>/dev/null || exitstatus=$? ; echo "${exitstatus}")
+  [ "${_exitstatus}" -eq 1 ]
+}


### PR DESCRIPTION
As is, shoreman preserves the exit status of the **last process** in the Procfile.

This proposed change overrides that, preserving instead the exit status of the **last non-success process** in the Procfile.